### PR TITLE
corrected the links to supp material

### DIFF
--- a/_posts/2025-04-23-chataigner25a.md
+++ b/_posts/2025-04-23-chataigner25a.md
@@ -48,6 +48,6 @@ issued:
 pdf: https://raw.githubusercontent.com/mlresearch/v279/main/assets/chataigner25a/chataigner25a.pdf
 extras:
 - label: Supplementary PDF
-  link: https://raw.githubusercontent.com/mlresearch/v279/main/assets/assets/chataigner25a/chataigner25a-supp.pdf
+  link: https://raw.githubusercontent.com/mlresearch/v279/main/assets/chataigner25a/chataigner25a-supp.pdf
 # Format based on Martin Fenner's citeproc: https://blog.front-matter.io/posts/citeproc-yaml-for-bibliographies/
 ---

--- a/_posts/2025-04-23-darur25a.md
+++ b/_posts/2025-04-23-darur25a.md
@@ -51,6 +51,6 @@ issued:
 pdf: https://raw.githubusercontent.com/mlresearch/v279/main/assets/darur25a/darur25a.pdf
 extras:
 - label: Supplementary PDF
-  link: https://raw.githubusercontent.com/mlresearch/v279/main/assets/assets/darur25a/darur25a-supp.pdf
+  link: https://raw.githubusercontent.com/mlresearch/v279/main/assets/darur25a/darur25a-supp.pdf
 # Format based on Martin Fenner's citeproc: https://blog.front-matter.io/posts/citeproc-yaml-for-bibliographies/
 ---

--- a/_posts/2025-04-23-ganesh25a.md
+++ b/_posts/2025-04-23-ganesh25a.md
@@ -53,6 +53,6 @@ issued:
 pdf: https://raw.githubusercontent.com/mlresearch/v279/main/assets/ganesh25a/ganesh25a.pdf
 extras:
 - label: Supplementary PDF
-  link: https://raw.githubusercontent.com/mlresearch/v279/main/assets/assets/ganesh25a/ganesh25a-supp.pdf
+  link: https://raw.githubusercontent.com/mlresearch/v279/main/assets/ganesh25a/ganesh25a-supp.pdf
 # Format based on Martin Fenner's citeproc: https://blog.front-matter.io/posts/citeproc-yaml-for-bibliographies/
 ---

--- a/_posts/2025-04-23-himmelreich25a.md
+++ b/_posts/2025-04-23-himmelreich25a.md
@@ -45,6 +45,6 @@ issued:
 pdf: https://raw.githubusercontent.com/mlresearch/v279/main/assets/himmelreich25a/himmelreich25a.pdf
 extras:
 - label: Supplementary PDF
-  link: https://raw.githubusercontent.com/mlresearch/v279/main/assets/assets/himmelreich25a/himmelreich25a-supp.pdf
+  link: https://raw.githubusercontent.com/mlresearch/v279/main/assets/himmelreich25a/himmelreich25a-supp.pdf
 # Format based on Martin Fenner's citeproc: https://blog.front-matter.io/posts/citeproc-yaml-for-bibliographies/
 ---

--- a/_posts/2025-04-23-hsu25a.md
+++ b/_posts/2025-04-23-hsu25a.md
@@ -54,6 +54,6 @@ issued:
 pdf: https://raw.githubusercontent.com/mlresearch/v279/main/assets/hsu25a/hsu25a.pdf
 extras:
 - label: Supplementary PDF
-  link: https://raw.githubusercontent.com/mlresearch/v279/main/assets/assets/hsu25a/hsu25a-supp.pdf
+  link: https://raw.githubusercontent.com/mlresearch/v279/main/assets/hsu25a/hsu25a-supp.pdf
 # Format based on Martin Fenner's citeproc: https://blog.front-matter.io/posts/citeproc-yaml-for-bibliographies/
 ---

--- a/_posts/2025-04-23-pentyala25a.md
+++ b/_posts/2025-04-23-pentyala25a.md
@@ -53,6 +53,6 @@ issued:
 pdf: https://raw.githubusercontent.com/mlresearch/v279/main/assets/pentyala25a/pentyala25a.pdf
 extras:
 - label: Supplementary PDF
-  link: https://raw.githubusercontent.com/mlresearch/v279/main/assets/assets/pentyala25a/pentyala25a-supp.pdf
+  link: https://raw.githubusercontent.com/mlresearch/v279/main/assets/pentyala25a/pentyala25a-supp.pdf
 # Format based on Martin Fenner's citeproc: https://blog.front-matter.io/posts/citeproc-yaml-for-bibliographies/
 ---

--- a/_posts/2025-04-23-powers25a.md
+++ b/_posts/2025-04-23-powers25a.md
@@ -56,6 +56,6 @@ issued:
 pdf: https://raw.githubusercontent.com/mlresearch/v279/main/assets/powers25a/powers25a.pdf
 extras:
 - label: Supplementary PDF
-  link: https://raw.githubusercontent.com/mlresearch/v279/main/assets/assets/powers25a/powers25a-supp.pdf
+  link: https://raw.githubusercontent.com/mlresearch/v279/main/assets/powers25a/powers25a-supp.pdf
 # Format based on Martin Fenner's citeproc: https://blog.front-matter.io/posts/citeproc-yaml-for-bibliographies/
 ---

--- a/_posts/2025-04-23-welfert25a.md
+++ b/_posts/2025-04-23-welfert25a.md
@@ -45,6 +45,6 @@ issued:
 pdf: https://raw.githubusercontent.com/mlresearch/v279/main/assets/welfert25a/welfert25a.pdf
 extras:
 - label: Supplementary PDF
-  link: https://raw.githubusercontent.com/mlresearch/v279/main/assets/assets/welfert25a/welfert25a-supp.pdf
+  link: https://raw.githubusercontent.com/mlresearch/v279/main/assets/welfert25a/welfert25a-supp.pdf
 # Format based on Martin Fenner's citeproc: https://blog.front-matter.io/posts/citeproc-yaml-for-bibliographies/
 ---


### PR DESCRIPTION
There was a double "asset" in the link to the supplementary material. I removed it.