### PR TITLE
Added "Workshop on" to the name of the proceedings

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 ---
-booktitle: Proceedings of the Algorithmic Fairness Through the Lens of Metrics and
+booktitle: Proceedings of the Workshop on Algorithmic Fairness Through the Lens of Metrics and
   Evaluation
 shortname: AFME
 year: '2024'
@@ -30,7 +30,7 @@ editor:
   family: Farnadi
 title: Proceedings of Machine Learning Research
 description: |
-  Proceedings of the Algorithmic Fairness Through the Lens of Metrics and Evaluation
+  Proceedings of the Workshop on Algorithmic Fairness Through the Lens of Metrics and Evaluation
     Held in Vancouver Convention Center, Vancouver, Canada on 14 December 2024
 
   Published as Volume 279 by the Proceedings of Machine Learning Research on 23 April 2025.


### PR DESCRIPTION
I added "Workshop on" to the name of the proceedings, such that it now reads: "Proceedings of the Workshop on Algorithmic Fairness Through the Lens of Metrics and Evaluation" instead of  "Proceedings of the Algorithmic Fairness Through the Lens of Metrics and Evaluation".